### PR TITLE
Added return value to pythonBinding init function.

### DIFF
--- a/src/PythonBinding.cpp
+++ b/src/PythonBinding.cpp
@@ -27,8 +27,9 @@ PythonBinding::~PythonBinding()
     }
 }
 
-void PythonBinding::init(QString p_module,QString p_path)
+bool PythonBinding::init(QString p_module,QString p_path)
 {
+    bool retVal=false;
     if(m_objCounter == 0){
         if(CPPFUNCMethods.size() != 0){
             PythonBinding::CPPFUNCModule = {
@@ -54,7 +55,11 @@ void PythonBinding::init(QString p_module,QString p_path)
 
     m_pName = PyUnicode_DecodeFSDefault(p_module.toUtf8());
     m_pModule = PyImport_Import(m_pName);
+    if (m_pModule !=  NULL){
+        retVal = true;
+    }
     Py_DECREF(m_pName);
+    return retVal;
 }
 
 PyObject* PythonBinding::callFunction(QString p_name,QList<PyObject*> p_args)

--- a/src/PythonBinding.h
+++ b/src/PythonBinding.h
@@ -74,7 +74,7 @@ public:
      * @param p_module: Name of the module
      * @param p_path: Path to the module folder (optional)
      */
-    void init(QString p_module, QString p_path="");
+    bool init(QString p_module, QString p_path="");
     /**
      * @brief callFunction
      * @param p_name: name of the function to call


### PR DESCRIPTION
Return true on success or false on error.

An error might have different reasons. For example the python module does not exist.

Signed-off-by: bhamacher <b.hamacher@zera.de>